### PR TITLE
Fix: Initial data initilization not working as expected

### DIFF
--- a/utils/addDummyData.ts
+++ b/utils/addDummyData.ts
@@ -4,7 +4,7 @@ import { ExpoSQLiteDatabase } from 'drizzle-orm/expo-sqlite';
 import AsyncStorage from 'expo-sqlite/kv-store';
 
 export const addDummyData = async (db: ExpoSQLiteDatabase) => {
-  const value = AsyncStorage.getItemSync('initialized');
+  const value = await AsyncStorage.getItemSync('initialized');
   if (value) return;
 
   await db.insert(projects).values([


### PR DESCRIPTION
This PR fixes the issue experienced around 1:30 where the initial data in `addDummyData` util function wasn't being initialized. `AsyncStorage.getItemAsync("initialized")` returns a Promise so we need to await the Promise to resolve first before evaluating whether the db is initialized or not.